### PR TITLE
[gcloud-workspace] Create image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Pre-requisites
 
 Images
 ------
-| Name                                       | Description                                                    |
-|--------------------------------------------|----------------------------------------------------------------|
-| [zeroplusx/kube-workspace](kube-workspace) | Kubernetes workspace image containing kubectl, helm, curl etc. |
-| [zeroplusx/middleman](middleman)           | Ruby/Bundler/Middleman image for generating static websites    |
-| [zeroplusx/static-nginx](static-nginx)     | Base image for static website builds to be served using nginx  |
-| [zeroplusx/yarn](yarn)                     | node/npm/yarn image for working with nodejs applications       |
+| Name                                           | Description                                                                    |
+|------------------------------------------------|--------------------------------------------------------------------------------|
+| [zeroplusx/gcloud-workspace](gcloud-workspace) | Google Cloud workspace image for authenticating and working with GCP resources |
+| [zeroplusx/kube-workspace](kube-workspace)     | Kubernetes workspace image containing kubectl, helm, curl etc.                 |
+| [zeroplusx/middleman](middleman)               | Ruby/Bundler/Middleman image for generating static websites                    |
+| [zeroplusx/static-nginx](static-nginx)         | Base image for static website builds to be served using nginx                  |
+| [zeroplusx/yarn](yarn)                         | node/npm/yarn image for working with nodejs applications                       |
 
 Snippets
 --------

--- a/gcloud-workspace/Dockerfile
+++ b/gcloud-workspace/Dockerfile
@@ -1,0 +1,21 @@
+FROM google/cloud-sdk:alpine
+
+LABEL vendor="0+X"
+LABEL maintainer="Sebastian Mandrean <sebastian@0x.se>"
+
+ENV HELM_VERSION 2.6.2
+ENV HELM_SRC https://storage.googleapis.com/kubernetes-helm/helm-v$HELM_VERSION-linux-amd64.tar.gz
+ENV HELM_DEST /usr/local/bin/helm
+
+# Install dependencies
+RUN apk --no-cache add git curl jq && \
+	apk --no-cache del wget && \
+	gcloud components update --quiet && \
+	gcloud components install kubectl --quiet
+
+# Install helm
+RUN curl -#SL $HELM_SRC | tar zxvf - && \
+	mv linux-amd64/helm $HELM_DEST && rm -rf linux-amd64 && \
+	chmod +x $HELM_DEST && \
+	mkdir -p ~/.kube && \
+	helm init -c

--- a/gcloud-workspace/README.md
+++ b/gcloud-workspace/README.md
@@ -1,0 +1,31 @@
+gcloud-workspace
+================
+Google Cloud workspace image for authenticating and working with GCP resources, based on [google/cloud-sdk:alpine](https://hub.docker.com/r/google/cloud-sdk/).
+
+Contains CLI tools such as [gcloud](https://cloud.google.com/sdk/gcloud/), [gsutil](https://cloud.google.com/storage/docs/gsutil), [kubectl](https://kubernetes.io/docs/user-guide/kubectl-overview/), [helm](https://helm.sh/), [jq](https://stedolan.github.io/jq/), curl and others.
+
+Usage
+-----
+In it's most simple form, you could run for example:
+
+```sh
+docker run --rm -it zeroplusx/gcloud-workspace gcloud version
+docker run --rm -it zeroplusx/gcloud-workspace kubectl version
+docker run --rm -it zeroplusx/gcloud-workspace helm version
+docker run --rm -it zeroplusx/gcloud-workspace curl --version
+```
+
+You could also mount a service account key and authenticate for more advanced features:
+
+```sh
+docker run --rm -it \
+	-v /path/to/service-account-key.json:/home/auth.json
+	
+	zeroplusx/gcloud-workspace gcloud auth activate-service-account --key-file /home/auth.json && \
+		gcloud container clusters get-credentials YOUR_GKE_CLUSTER --project YOUR_GCP_PROJECT && \
+		gcloud container clusters list
+```
+
+Maintainers
+-----------
+* Sebastian Mandrean (<sebastian@0x.se>)


### PR DESCRIPTION
Google Cloud workspace image for authenticating and working with GCP resources, based on [google/cloud-sdk:alpine](https://hub.docker.com/r/google/cloud-sdk/).

Contains CLI tools such as [gcloud](https://cloud.google.com/sdk/gcloud/), [gsutil](https://cloud.google.com/storage/docs/gsutil), [kubectl](https://kubernetes.io/docs/user-guide/kubectl-overview/), [helm](https://helm.sh/), [jq](https://stedolan.github.io/jq/), curl and others.