### PR TITLE
[static-nginx] Use explicit nginx conf and listen to port 8080

### DIFF
--- a/static-nginx/Dockerfile
+++ b/static-nginx/Dockerfile
@@ -5,4 +5,4 @@ LABEL maintainer="Sebastian Mandrean <sebastian@0x.se>"
 
 RUN rm -rf /usr/share/nginx/html && mkdir -p /usr/share/nginx/html
 
-ADD nginx.conf /etc/nginx/conf.d/default.conf
+ADD default.conf /etc/nginx/conf.d/default.conf

--- a/static-nginx/default.conf
+++ b/static-nginx/default.conf
@@ -1,5 +1,6 @@
 server {
     listen       80;
+    listen       8000;
     server_name  localhost;
 
     #charset koi8-r;


### PR DESCRIPTION
This PR switches over to using an explicit nginx conf, and additionally listening to port 8080.