### PR TITLE
[static-nginx] Fix typo of port 8000 to 8080

### DIFF
--- a/static-nginx/README.md
+++ b/static-nginx/README.md
@@ -11,6 +11,11 @@ docker run -v $(pwd):/usr/share/nginx/html -p 8080:80 zeroplusx/static-nginx
 ```
 Then just open http://localhost:8080 in your browser.
 
+Nginx also listens to container port 8080, for scenarios where that might be needed:
+```sh
+docker run -v $(pwd):/usr/share/nginx/html -p 8080:8080 zeroplusx/static-nginx
+```
+
 More likely is that `zeroplusx/static-nginx` will be used as a base image for static website builds. Using the default `nginx.conf`, you should add your files to `/usr/share/nginx/html`:
 
 ```dockerfile

--- a/static-nginx/default.conf
+++ b/static-nginx/default.conf
@@ -1,6 +1,6 @@
 server {
     listen       80;
-    listen       8000;
+    listen       8080;
     server_name  localhost;
 
     #charset koi8-r;


### PR DESCRIPTION
This PR fixes a small typo in the previous PR. Port 8000 should in fact be port 8080.