### PR TITLE
[gcloud-workspace] Add Docker CLI client

### DIFF
--- a/gcloud-workspace/Dockerfile
+++ b/gcloud-workspace/Dockerfile
@@ -12,7 +12,7 @@ ENV SKAFFOLD_SRC https://storage.googleapis.com/skaffold/releases/$SKAFFOLD_VERS
 ENV SKAFFOLD_DEST /usr/local/bin/skaffold
 
 # Install dependencies
-RUN apk --no-cache add git curl jq && \
+RUN apk --no-cache add git curl jq docker && \
 	apk --no-cache del wget && \
 	gcloud components update --quiet && \
 	gcloud components install kubectl --quiet

--- a/gcloud-workspace/README.md
+++ b/gcloud-workspace/README.md
@@ -2,25 +2,27 @@ gcloud-workspace
 ================
 Google Cloud workspace image for authenticating and working with GCP resources, based on [google/cloud-sdk:alpine](https://hub.docker.com/r/google/cloud-sdk/).
 
-Contains CLI tools such as [gcloud](https://cloud.google.com/sdk/gcloud/), [gsutil](https://cloud.google.com/storage/docs/gsutil), [kubectl](https://kubernetes.io/docs/user-guide/kubectl-overview/), [helm](https://helm.sh/), [jq](https://stedolan.github.io/jq/), curl and others.
+Contains CLI tools such as [gcloud](https://cloud.google.com/sdk/gcloud/), [gsutil](https://cloud.google.com/storage/docs/gsutil), [docker](https://docs.docker.com/engine/reference/commandline/cli/), [kubectl](https://kubernetes.io/docs/user-guide/kubectl-overview/), [helm](https://helm.sh/), [skaffold](https://github.com/GoogleContainerTools/skaffold), [jq](https://stedolan.github.io/jq/), curl and others.
 
 Usage
 -----
 In it's most simple form, you could run for example:
 
 ```sh
-docker run --rm -it zeroplusx/gcloud-workspace gcloud version
-docker run --rm -it zeroplusx/gcloud-workspace kubectl version
-docker run --rm -it zeroplusx/gcloud-workspace helm version
-docker run --rm -it zeroplusx/gcloud-workspace curl --version
+docker run --rm zeroplusx/gcloud-workspace gcloud version
+docker run --rm zeroplusx/gcloud-workspace docker version
+docker run --rm zeroplusx/gcloud-workspace kubectl version
+docker run --rm zeroplusx/gcloud-workspace helm version
+docker run --rm zeroplusx/gcloud-workspace skaffold version
+docker run --rm zeroplusx/gcloud-workspace curl --version
 ```
 
 You could also mount a service account key and authenticate for more advanced features:
 
 ```sh
-docker run --rm -it \
+docker run --rm \
 	-v /path/to/service-account-key.json:/home/auth.json
-	
+
 	zeroplusx/gcloud-workspace gcloud auth activate-service-account --key-file /home/auth.json && \
 		gcloud container clusters get-credentials YOUR_GKE_CLUSTER --project YOUR_GCP_PROJECT && \
 		gcloud container clusters list


### PR DESCRIPTION
This PR adds the [Docker CLI client](https://docs.docker.com/engine/reference/commandline/cli/) and updates the README documentation.