### PR TITLE
Configure Gcloud Docker Credential Helper

### DIFF
--- a/gcloud-workspace/Dockerfile
+++ b/gcloud-workspace/Dockerfile
@@ -25,6 +25,7 @@ RUN apk --no-cache add git curl jq docker ca-certificates && \
 
 # Update & install gcloud dependencies
 RUN gcloud components update --quiet && \
+	gcloud auth configure-docker && \
 
 	# Kubectl
 	gcloud components install kubectl --quiet && \


### PR DESCRIPTION
This PR configures Docker to use the Gcloud Credential Helper by default for Google Container Registry.